### PR TITLE
fix: fallback to Rails.logger if no logger provided

### DIFF
--- a/lib/casino.rb
+++ b/lib/casino.rb
@@ -11,7 +11,7 @@ module CASino
     allow_remember_me: true,
     allow_forgot_password: true,
     allow_change_password: true,
-    logger: Rails.logger,
+    logger: nil,
     frontend: HashWithIndifferentAccess.new(
       sso_name: 'CASino',
       footer_text: 'Powered by <a href="http://rbcas.com/">CASino</a>'

--- a/lib/casino/engine.rb
+++ b/lib/casino/engine.rb
@@ -25,6 +25,7 @@ module CASino
         end
         CASino.config.send("#{k}=", value)
       end
+      CASino.config.logger = Rails.logger if CASino.config.logger.nil?
     end
 
     def load_file(filename)


### PR DESCRIPTION
`Rails.logger` is not available in `lib/casino.rb` thus causes a Runtime error when a logger is not configured and `CASino.logger` is called